### PR TITLE
Update small typo in xxxx-c-sparse-observable.md

### DIFF
--- a/xxxx-c-sparse-observable.md
+++ b/xxxx-c-sparse-observable.md
@@ -147,7 +147,7 @@ obs_free(obs);  // once we're done, free the observable (remember, paulis is alr
 * ... 
 
 #### Data access
-* ``obs_term(SparseObservable*, uint64_t*) -> SparseTerm*``
+* ``obs_term(SparseObservable*, uint64_t) -> SparseTerm*``
 * ``obs_num_terms(SparseObservable*) -> uint64_t`` 
 * ``obs_num_qubits(SparseObservable*) -> uint32_t``
 * ...


### PR DESCRIPTION
Either there is a typo here, or it needs to be `obs_term(obs, &i)` in the loop below.